### PR TITLE
#5 | UA_4: Add jasper to jrxml decompile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
             <artifactId>log4j-slf4j2-impl</artifactId>
             <version>2.24.1</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/net.sf.jasperreports/jasperreports -->
+        <dependency>
+            <groupId>net.sf.jasperreports</groupId>
+            <artifactId>jasperreports</artifactId>
+            <version>6.21.3</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/app/controller/ConverterController.java
+++ b/src/main/java/app/controller/ConverterController.java
@@ -158,6 +158,9 @@ public class ConverterController extends GenericController {
         String name = sourceFile.getName().toLowerCase();
         String[] splits = name.split("\\.");
         int i = splits.length - 1;
+        if (splits.length < 2 || splits[splits.length - 1].isEmpty()) {
+            throw new ConversionErrorException("Il file non ha un'estensione valida: " + sourceFile.getAbsolutePath());
+        }
         return switch (splits[i]) {
             case "jasper" -> "application/x-jasper";
             case "jrxml" -> "application/jasper-jrxml";

--- a/src/main/java/app/controller/ConverterController.java
+++ b/src/main/java/app/controller/ConverterController.java
@@ -72,7 +72,8 @@ public class ConverterController extends GenericController {
             sourceFile = file;
             sourceFilePath.setText(file.getAbsolutePath());
 
-            MimeType inputType = MimeType.fromString(guessMimeType(sourceFile));
+            String sourceMimeType = guessMimeType(sourceFile);
+            MimeType inputType = MimeType.fromString(sourceMimeType);
             List<String> availableOutputs = new ArrayList<>();
             for (FileConverter c : converterRegistry.getAllConverters()) {
                 if (c.getInputMimeType().equals(inputType)) {
@@ -142,10 +143,26 @@ public class ConverterController extends GenericController {
         Tika tika = new Tika();
         try {
             LOGGER.info("Rilevamento del tipo MIME per il file: {}", file.getAbsolutePath());
-            return tika.detect(file);
+            String mimeType = tika.detect(file);
+            if ("application/octet-stream".equals(mimeType)) {
+                mimeType = specialMimeTypeCheck(file);
+            }
+            return mimeType;
         } catch (IOException e) {
             LOGGER.error("Errore nel rilevamento del tipo MIME: {}", e.getMessage());
             throw new ConversionErrorException("Errore nel rilevamento del tipo MIME: " + e.getMessage());
         }
+    }
+
+    private String specialMimeTypeCheck(File sourceFile) throws ConversionErrorException {
+        String name = sourceFile.getName().toLowerCase();
+        String[] splits = name.split("\\.");
+        int i = splits.length - 1;
+        return switch (splits[i]) {
+            case "jasper" -> "application/x-jasper";
+            case "jrxml" -> "application/jasper-jrxml";
+            default ->
+                    throw new ConversionErrorException("Tipo MIME non riconosciuto per il file: " + sourceFile.getAbsolutePath());
+        };
     }
 }

--- a/src/main/java/app/converter/ConverterRegistry.java
+++ b/src/main/java/app/converter/ConverterRegistry.java
@@ -18,6 +18,8 @@ public class ConverterRegistry {
         converters.add(new Mp4ToMp3ConverterUtils());
         converters.add(new Mp4ToWavConverterUtils());
         converters.add(new PngToJpgConverterUtils());
+        converters.add(new JasperToJrxmlConverterUtils());
+        LOGGER.info("Registro dei convertitori inizializzato con {} convertitori", converters.size());
     }
 
     public Optional<FileConverter> getConverter(MimeType input, MimeType output) {

--- a/src/main/java/app/converter/JasperToJrxmlConverterUtils.java
+++ b/src/main/java/app/converter/JasperToJrxmlConverterUtils.java
@@ -1,0 +1,56 @@
+package app.converter;
+
+import app.enums.MimeType;
+import app.exception.ConversionErrorException;
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JasperReport;
+import net.sf.jasperreports.engine.util.JRLoader;
+import net.sf.jasperreports.engine.xml.JRXmlWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Map;
+
+public class JasperToJrxmlConverterUtils extends ConverterUtils implements FileConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JasperToJrxmlConverterUtils.class);
+
+    @Override
+    public MimeType getInputMimeType() {
+        return MimeType.JASPER_COMPILED;
+    }
+
+    @Override
+    public MimeType getOutputMimeType() {
+        return MimeType.JASPER_JRXML;
+    }
+
+    @Override
+    public void convert(File source, File dest, Map<String, Object> options) throws ConversionErrorException {
+        LOGGER.info("Avvio conversione da JASPER a JRXML: {} -> {}", source.getAbsolutePath(), dest.getAbsolutePath());
+        if (!source.exists()) {
+            LOGGER.error("File sorgente non trovato: {}", source.getAbsolutePath());
+            throw new ConversionErrorException("File sorgente non trovato: " + source.getAbsolutePath());
+        }
+        try {
+            File parent = dest.getParentFile();
+            if (parent != null && !parent.exists()) {
+                if (!parent.mkdirs()) {
+                    LOGGER.warn("Impossibile creare la directory di destinazione: {}", parent.getAbsolutePath());
+                }
+            }
+
+            JasperReport report = (JasperReport)
+                    JRLoader.loadObject(source);
+
+            String jrxmlPath = dest.getAbsolutePath();
+            JRXmlWriter.writeReport(report, jrxmlPath, "UTF-8");
+
+            LOGGER.info("Conversione completata: {}", jrxmlPath);
+        } catch (JRException ex) {
+            LOGGER.error("Errore durante la conversione", ex);
+            throw new ConversionErrorException("Errore durante la conversione: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/app/converter/JasperToJrxmlConverterUtils.java
+++ b/src/main/java/app/converter/JasperToJrxmlConverterUtils.java
@@ -41,8 +41,11 @@ public class JasperToJrxmlConverterUtils extends ConverterUtils implements FileC
                 }
             }
 
-            JasperReport report = (JasperReport)
-                    JRLoader.loadObject(source);
+            Object loadedObject = JRLoader.loadObject(source);
+            if (!(loadedObject instanceof JasperReport report)) {
+                LOGGER.error("Il file {} non contiene un oggetto JasperReport valido.", source.getAbsolutePath());
+                throw new ConversionErrorException("Il file " + source.getAbsolutePath() + " non contiene un oggetto JasperReport valido.");
+            }
 
             String jrxmlPath = dest.getAbsolutePath();
             JRXmlWriter.writeReport(report, jrxmlPath, "UTF-8");

--- a/src/main/java/app/enums/MimeType.java
+++ b/src/main/java/app/enums/MimeType.java
@@ -7,7 +7,9 @@ public enum MimeType {
     AUDIO_MP3("audio/mpeg", ".mp3"),
     AUDIO_WAV("audio/wav", ".wav"),
     IMAGE_PNG("image/png", ".png"),
-    IMAGE_JPEG("image/jpeg", ".jpg");
+    IMAGE_JPEG("image/jpeg", ".jpg"),
+    JASPER_JRXML("application/jasper-jrxml", ".jrxml"),
+    JASPER_COMPILED("application/x-jasper", ".jasper");
 
     private final String value;
     private final String extension;


### PR DESCRIPTION
Added jasper to jrxml decompile:
- new mime types JASPER_JRXML and JASPER_COMPILED
- new method inside ConverterController to handle special mime type that cannot be recognized by Tika